### PR TITLE
Update operations_test.go

### DIFF
--- a/pkg/geometry/operations_test.go
+++ b/pkg/geometry/operations_test.go
@@ -150,6 +150,44 @@ func TestCompressCentroids_MaxPointsOne(t *testing.T) {
 	}
 }
 
+func TestCompressCentroids_MaxPointsTwo(t *testing.T) {
+	centroids := [][2]float64{{0, 0}, {1, 1}, {2, 2}, {700, 500}, {909, 1560}, {2, 2}, {1, 1}, {0, 0}}
+	got := CompressCentroids(centroids, 3)
+	if len(got) != 3 {
+		t.Fatalf("maxPoints=3: got len=%d, want 3; got=%v", len(got), got)
+	}
+	// Expect first input representative preserved
+	if got[0] != centroids[0] {
+		t.Fatalf("maxPoints=3: first point mismatch: got %v, want %v", got[0], centroids[0])
+	}
+}
+
+func TestCompressCentroids_MaxPointsEqualToLength(t *testing.T) {
+	centroids := [][2]float64{{0, 0}, {1, 1}, {2, 2}, {700, 500}, {909, 1560}, {2, 2}, {1, 1}, {0, 0}}
+	got := CompressCentroids(centroids, 8)
+	if len(got) != 8 {
+		t.Fatalf("maxPoints=8: got len=%d, want 8; got=%v", len(got), got)
+	}
+	// Expect first input representative preserved
+	if got[0] != centroids[0] {
+		t.Fatalf("maxPoints=8: first point mismatch: got %v, want %v", got[0], centroids[0])
+	}
+}
+
+// Testing if points equally spaced returns expected count when maxPoints does not evenly divide.
+func TestCompressCentroids_MaxPointsDividedEqually(t *testing.T) {
+	centroids := [][2]float64{{0, 0}, {0, 1}, {1, 0}, {2, 0}, {0, 2}, {2, 2}, {1, 1}, {1, 2}}
+	got := CompressCentroids(centroids, 4)
+	if len(got) != 4 {
+		t.Fatalf("maxPoints=4: got len=%d, want 4; got=%v", len(got), got)
+	}
+
+	// Expect first input representative preserved
+	if got[0] != centroids[0] {
+		t.Fatalf("maxPoints=4: first point mismatch: got %v, want %v", got[0], centroids[0])
+	}
+}
+
 // helper to recompute the intermediate reduced set like the implementation, for property checks.
 func recomputeReduced(centroids [][2]float64, maxPoints int) (reduced [][2]float64) {
 	if len(centroids) == 0 {


### PR DESCRIPTION
## Description

### Pull Request: Update operations_test.go

#### Motivation
The primary motivation behind this pull request is to enhance the test coverage of the `CompressCentroids` function within the `operations_test.go` file. By adding more test cases, we aim to ensure the robustness and reliability of the centroid compression logic, particularly under different scenarios and edge cases.

#### Changes
1. **New Test Cases Added**:
    - `TestCompressCentroids_MaxPointsTwo`: Tests the behavior of `CompressCentroids` when the maximum points allowed is less than the length of the input array.
    - `TestCompressCentroids_MaxPointsEqualToLength`: Verifies that the function correctly handles the case where the maximum points allowed is equal to the length of the input array.
    - `TestCompressCentroids_MaxPointsDividedEqually`: Checks if the function correctly handles points that are equally spaced when the maximum points allowed does not evenly divide the length of the input array.

#### Improvements
1. **Enhanced Test Coverage**: The new test cases cover additional scenarios and edge cases, ensuring the `CompressCentroids` function behaves as expected under various conditions.
2. **Increased Reliability**: By verifying the function's output in more detail, we can catch potential bugs and regressions early in the development process.
3. **Better Maintenance**: Comprehensive test cases make it easier to understand the expected behavior of the function, facilitating future maintenance and updates.

Overall, these changes contribute to the robustness and reliability of the geometry operations module, ensuring that the `CompressCentroids` function performs correctly across different input scenarios.