### PR TITLE
Fix edge case in CompressCentroids for maxPoints=1

### DIFF
--- a/pkg/geometry/operations.go
+++ b/pkg/geometry/operations.go
@@ -61,6 +61,13 @@ func CompressCentroids(centroids [][2]float64, maxPoints int) [][2]float64 {
 		return reduced
 	}
 
+	// Edge case: when maxPoints==1, the downsampling step denominator (maxPoints-1)
+	// would be zero, leading to NaN/Inf indices when casting to int in some Go builds.
+	// Return the first representative point from the reduced set to avoid invalid indexing.
+	if maxPoints == 1 {
+		return reduced[:1]
+	}
+
 	step := float64(len(reduced)-1) / float64(maxPoints-1)
 	downsampled := make([][2]float64, 0, maxPoints)
 	for i := 0; i < maxPoints; i++ {


### PR DESCRIPTION
## Description

### Fix edge case in CompressCentroids for maxPoints=1

#### Motivation

The function `CompressCentroids` encounters an edge case when `maxPoints` is set to 1. In this scenario, the denominator `maxPoints-1` becomes zero, which leads to invalid indexing operations that result in NaN or Inf values in some Go builds.

#### Improvement

By handling this edge case explicitly, the function now returns the first representative point from the reduced set when `maxPoints` equals 1. This avoids invalid indexing and ensures the function behaves correctly across all inputs. This fix improves the robustness and reliability of the `CompressCentroids` function, preventing potential crashes or undefined behavior due to improper handling of edge cases.

#### Changes

- Added a conditional check for `maxPoints == 1` in the `CompressCentroids` function.
- When `maxPoints` is 1, the function returns the first point from the reduced set, avoiding invalid indexing operations.

This change ensures that the `CompressCentroids` function can handle all valid inputs without encountering indexing errors, thereby improving the stability and correctness of the project.